### PR TITLE
feat(postgres): Add instructors table with migration and entity

### DIFF
--- a/packages/postgres/src/entities/index.ts
+++ b/packages/postgres/src/entities/index.ts
@@ -1,6 +1,7 @@
 import { BaseEntity } from './base.entity';
+import { Instructor } from './instructor.entity';
 import { User } from './user.entity';
 
-export const entities = [BaseEntity, User];
+export const entities = [BaseEntity, User, Instructor];
 
-export { BaseEntity, User };
+export { BaseEntity, User, Instructor };

--- a/packages/postgres/src/entities/instructor.entity.ts
+++ b/packages/postgres/src/entities/instructor.entity.ts
@@ -1,0 +1,58 @@
+import { Column, Entity, JoinColumn, OneToOne } from 'typeorm';
+import { BaseEntity } from './base.entity';
+import { User } from './user.entity';
+
+/**
+ * TABLE-NAME: instructors
+ * TABLE-DESCRIPTION: Stores instructor-specific details and statistics for users acting as instructors
+ * TABLE-IMPORTANT-CONSTRAINTS:
+ *   - user_id must be unique (one user can only be one instructor)
+ *   - user_id is a foreign key referencing users.id with CASCADE on delete
+ *   - bio is nullable (instructors may not have a bio)
+ *   - rating is nullable with precision 3 and scale 2 (e.g., 4.50)
+ *   - inherits id (UUID), createdAt, updatedAt, and deletedAt from BaseEntity
+ * TABLE-RELATIONSHIPS:
+ *   - One-to-one relationship with User (each instructor is associated with exactly one user)
+ */
+@Entity('instructors')
+export class Instructor extends BaseEntity {
+  /**
+   * COLUMN-DESCRIPTION: Foreign key referencing the user who is an instructor, must be unique
+   */
+  @Column({
+    type: 'uuid',
+    name: 'user_id',
+    unique: true,
+    nullable: false,
+  })
+  public userId: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Biographical information about the instructor
+   */
+  @Column({
+    type: 'text',
+    name: 'bio',
+    nullable: true,
+  })
+  public bio: string | null;
+
+  /**
+   * COLUMN-DESCRIPTION: Average rating for the instructor with precision 3 and scale 2 (e.g., 4.50)
+   */
+  @Column({
+    type: 'numeric',
+    precision: 3,
+    scale: 2,
+    name: 'rating',
+    nullable: true,
+  })
+  public rating: number | null;
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: One-to-one relationship with User entity
+   */
+  @OneToOne(() => User, (user) => user.instructor)
+  @JoinColumn({ name: 'user_id' })
+  public user: User;
+}

--- a/packages/postgres/src/entities/user.entity.ts
+++ b/packages/postgres/src/entities/user.entity.ts
@@ -1,5 +1,7 @@
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, OneToOne } from 'typeorm';
 import { BaseEntity } from './base.entity';
+import { Instructor } from './instructor.entity';
+
 /**
  * TABLE-NAME: users
  * TABLE-DESCRIPTION: Stores user authentication credentials and basic user information
@@ -35,4 +37,12 @@ export class User extends BaseEntity {
     select: false,
   })
   public password: string;
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: One-to-one relationship with Instructor entity (optional)
+   */
+  @OneToOne(() => Instructor, (instructor) => instructor.user, {
+    nullable: true,
+  })
+  public instructor?: Instructor;
 }

--- a/packages/postgres/src/migrations/1762165499123-CreateInstructorsTable.ts
+++ b/packages/postgres/src/migrations/1762165499123-CreateInstructorsTable.ts
@@ -1,0 +1,46 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { DatabaseCreateForeignKey, DatabaseCreateTable } from './utils';
+
+export class CreateInstructorsTable1762165499123 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create instructors table
+    await DatabaseCreateTable(queryRunner, 'instructors', [
+      {
+        name: 'user_id',
+        type: 'uuid',
+        isUnique: true,
+        isNullable: false,
+      },
+      {
+        name: 'bio',
+        type: 'text',
+        isNullable: true,
+      },
+      {
+        name: 'rating',
+        type: 'numeric',
+        precision: 3,
+        scale: 2,
+        isNullable: true,
+      },
+    ]);
+
+    // Create foreign key from instructors.user_id to users.id
+    await DatabaseCreateForeignKey(
+      queryRunner,
+      'instructors',
+      'users',
+      'user_id',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop foreign key first
+    await queryRunner.query(
+      `ALTER TABLE "instructors" DROP CONSTRAINT IF EXISTS "FK_instructors_users"`,
+    );
+
+    // Drop table
+    await queryRunner.dropTable('instructors');
+  }
+}


### PR DESCRIPTION
## 📋 Description

This PR implements the database schema changes for the `instructors` table as specified in issue #1.

## 🔧 Changes Made

### Database Migration
- Created migration `1762165499123-CreateInstructorsTable.ts` to add the `instructors` table
- Table includes:
  - `id` (UUID, PK) - inherited from BaseEntity
  - `user_id` (UUID, FK to users.id, unique, not null)
  - `bio` (TEXT, nullable)
  - `rating` (NUMERIC(3,2), nullable)
  - `created_at`, `updated_at`, `deleted_at` - inherited from BaseEntity
- Foreign key constraint from `instructors.user_id` to `users.id` with CASCADE on delete
- Migration tested with run/revert cycles to ensure full reversibility

### Entity Changes
- Created `Instructor` entity with proper TypeORM decorators
- Updated `User` entity to include one-to-one relationship with `Instructor`
- Updated `packages/postgres/src/entities/index.ts` to export the new entity
- All entities include comprehensive JSDoc documentation

## ✅ Verification

- [x] SUBTASK-01: Created feature branch from main
- [x] SUBTASK-02: Validated inputs and prepared workspace
- [x] SUBTASK-03: Read Postgres Rules
- [x] SUBTASK-04: Reviewed previous migrations for conflicts
- [x] SUBTASK-05: Created migration file
- [x] SUBTASK-06: Implemented up and down methods
- [x] SUBTASK-07: Tested run and revert twice (confirmed reversibility)
- [x] SUBTASK-08: No enums required for this change
- [x] SUBTASK-09: Created instructor entity
- [x] SUBTASK-10: Entity documentation is complete
- [x] SUBTASK-11: TypeScript builds and lints pass
- [x] SUBTASK-12: Final readiness check complete
- [x] SUBTASK-13: General rule compliance verified

## 📝 Migration Commands

To apply this migration:
```bash
cd packages/postgres
npm run migration:run
```

To revert this migration:
```bash
cd packages/postgres
npm run migration:revert
```

## 🔗 Related Issue

Closes #1