### PR TITLE
feat(database): Add courses, sections, and lessons tables

### DIFF
--- a/packages/enums/src/courses-status.enum.ts
+++ b/packages/enums/src/courses-status.enum.ts
@@ -1,0 +1,29 @@
+/**
+ * Status values for courses in the courses table
+ */
+export enum CoursesStatusEnum {
+  /**
+   * Course is in draft mode and not visible to students
+   */
+  DRAFT = 'DRAFT',
+
+  /**
+   * Course is under review by administrators
+   */
+  REVIEW = 'REVIEW',
+
+  /**
+   * Course is published and visible to students
+   */
+  PUBLISHED = 'PUBLISHED',
+
+  /**
+   * Course is archived and no longer active
+   */
+  ARCHIVED = 'ARCHIVED',
+
+  /**
+   * Course is marked as deleted (soft delete)
+   */
+  DELETED = 'DELETED',
+}

--- a/packages/enums/src/index.ts
+++ b/packages/enums/src/index.ts
@@ -1,1 +1,2 @@
+export { CoursesStatusEnum } from './courses-status.enum';
 export { SortEnum } from './sort.enum';

--- a/packages/postgres/src/entities/course.entity.ts
+++ b/packages/postgres/src/entities/course.entity.ts
@@ -1,0 +1,77 @@
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
+import { BaseEntity } from './base.entity';
+import { Instructor } from './instructor.entity';
+import { Section } from './section.entity';
+import { CoursesStatusEnum } from '@repo/enums';
+
+/**
+ * TABLE-NAME: courses
+ * TABLE-DESCRIPTION: Main catalog of available courses
+ * TABLE-IMPORTANT-CONSTRAINTS:
+ *   - instructor_id is a foreign key referencing instructors.id with CASCADE on delete
+ *   - status is an enum with values: DRAFT, REVIEW, PUBLISHED, ARCHIVED, DELETED
+ *   - title is required and has maximum 255 characters
+ *   - description is optional text field
+ *   - inherits id (UUID), createdAt, updatedAt, and deletedAt from BaseEntity
+ * TABLE-RELATIONSHIPS:
+ *   - Many-to-one relationship with Instructor (each course belongs to one instructor)
+ *   - One-to-many relationship with Section (a course can have multiple sections)
+ */
+@Entity('courses')
+export class Course extends BaseEntity {
+  /**
+   * COLUMN-DESCRIPTION: Foreign key referencing the instructor who created/owns this course
+   */
+  @Column({
+    type: 'uuid',
+    name: 'instructor_id',
+    nullable: false,
+  })
+  public instructorId: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Title of the course, maximum 255 characters
+   */
+  @Column({
+    type: 'varchar',
+    length: 255,
+    name: 'title',
+    nullable: false,
+  })
+  public title: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Detailed description of the course content
+   */
+  @Column({
+    type: 'text',
+    name: 'description',
+    nullable: true,
+  })
+  public description: string | null;
+
+  /**
+   * COLUMN-DESCRIPTION: Current status of the course (DRAFT, REVIEW, PUBLISHED, ARCHIVED, DELETED)
+   */
+  @Column({
+    type: 'varchar',
+    length: 50,
+    name: 'status',
+    nullable: false,
+    default: CoursesStatusEnum.DRAFT,
+  })
+  public status: CoursesStatusEnum;
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: Many-to-one relationship with Instructor entity
+   */
+  @ManyToOne(() => Instructor, (instructor) => instructor.courses)
+  @JoinColumn({ name: 'instructor_id' })
+  public instructor: Instructor;
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: One-to-many relationship with Section entity
+   */
+  @OneToMany(() => Section, (section) => section.course)
+  public sections: Section[];
+}

--- a/packages/postgres/src/entities/index.ts
+++ b/packages/postgres/src/entities/index.ts
@@ -1,7 +1,10 @@
 import { BaseEntity } from './base.entity';
+import { Course } from './course.entity';
 import { Instructor } from './instructor.entity';
+import { Lesson } from './lesson.entity';
+import { Section } from './section.entity';
 import { User } from './user.entity';
 
-export const entities = [BaseEntity, User, Instructor];
+export const entities = [BaseEntity, User, Instructor, Course, Section, Lesson];
 
-export { BaseEntity, User, Instructor };
+export { BaseEntity, User, Instructor, Course, Section, Lesson };

--- a/packages/postgres/src/entities/instructor.entity.ts
+++ b/packages/postgres/src/entities/instructor.entity.ts
@@ -1,6 +1,7 @@
-import { Column, Entity, JoinColumn, OneToOne } from 'typeorm';
+import { Column, Entity, JoinColumn, OneToMany, OneToOne } from 'typeorm';
 import { BaseEntity } from './base.entity';
 import { User } from './user.entity';
+import { Course } from './course.entity';
 
 /**
  * TABLE-NAME: instructors
@@ -13,6 +14,7 @@ import { User } from './user.entity';
  *   - inherits id (UUID), createdAt, updatedAt, and deletedAt from BaseEntity
  * TABLE-RELATIONSHIPS:
  *   - One-to-one relationship with User (each instructor is associated with exactly one user)
+ *   - One-to-many relationship with Course (an instructor can have multiple courses)
  */
 @Entity('instructors')
 export class Instructor extends BaseEntity {
@@ -55,4 +57,10 @@ export class Instructor extends BaseEntity {
   @OneToOne(() => User, (user) => user.instructor)
   @JoinColumn({ name: 'user_id' })
   public user: User;
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: One-to-many relationship with Course entity
+   */
+  @OneToMany(() => Course, (course) => course.instructor)
+  public courses: Course[];
 }

--- a/packages/postgres/src/entities/lesson.entity.ts
+++ b/packages/postgres/src/entities/lesson.entity.ts
@@ -1,0 +1,55 @@
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseEntity } from './base.entity';
+import { Section } from './section.entity';
+
+/**
+ * TABLE-NAME: lessons
+ * TABLE-DESCRIPTION: The individual learning content unit (video, quiz, article)
+ * TABLE-IMPORTANT-CONSTRAINTS:
+ *   - section_id is a foreign key referencing sections.id with CASCADE on delete
+ *   - title is required and has maximum 255 characters
+ *   - content_url is optional and stores the URL to the lesson content
+ *   - inherits id (UUID), createdAt, updatedAt, and deletedAt from BaseEntity
+ * TABLE-RELATIONSHIPS:
+ *   - Many-to-one relationship with Section (each lesson belongs to one section)
+ */
+@Entity('lessons')
+export class Lesson extends BaseEntity {
+  /**
+   * COLUMN-DESCRIPTION: Foreign key referencing the section this lesson belongs to
+   */
+  @Column({
+    type: 'uuid',
+    name: 'section_id',
+    nullable: false,
+  })
+  public sectionId: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Title of the lesson, maximum 255 characters
+   */
+  @Column({
+    type: 'varchar',
+    length: 255,
+    name: 'title',
+    nullable: false,
+  })
+  public title: string;
+
+  /**
+   * COLUMN-DESCRIPTION: URL to the lesson content (video, quiz, article, etc.)
+   */
+  @Column({
+    type: 'text',
+    name: 'content_url',
+    nullable: true,
+  })
+  public contentUrl: string | null;
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: Many-to-one relationship with Section entity
+   */
+  @ManyToOne(() => Section, (section) => section.lessons)
+  @JoinColumn({ name: 'section_id' })
+  public section: Section;
+}

--- a/packages/postgres/src/entities/section.entity.ts
+++ b/packages/postgres/src/entities/section.entity.ts
@@ -1,0 +1,64 @@
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
+import { BaseEntity } from './base.entity';
+import { Course } from './course.entity';
+import { Lesson } from './lesson.entity';
+
+/**
+ * TABLE-NAME: sections
+ * TABLE-DESCRIPTION: Logical grouping of lessons within a course
+ * TABLE-IMPORTANT-CONSTRAINTS:
+ *   - course_id is a foreign key referencing courses.id with CASCADE on delete
+ *   - title is required and has maximum 255 characters
+ *   - order_index defines the display order of sections within a course
+ *   - inherits id (UUID), createdAt, updatedAt, and deletedAt from BaseEntity
+ * TABLE-RELATIONSHIPS:
+ *   - Many-to-one relationship with Course (each section belongs to one course)
+ *   - One-to-many relationship with Lesson (a section can have multiple lessons)
+ */
+@Entity('sections')
+export class Section extends BaseEntity {
+  /**
+   * COLUMN-DESCRIPTION: Foreign key referencing the course this section belongs to
+   */
+  @Column({
+    type: 'uuid',
+    name: 'course_id',
+    nullable: false,
+  })
+  public courseId: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Title of the section, maximum 255 characters
+   */
+  @Column({
+    type: 'varchar',
+    length: 255,
+    name: 'title',
+    nullable: false,
+  })
+  public title: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Order index for displaying sections in sequence within a course
+   */
+  @Column({
+    type: 'integer',
+    name: 'order_index',
+    nullable: false,
+    default: 0,
+  })
+  public orderIndex: number;
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: Many-to-one relationship with Course entity
+   */
+  @ManyToOne(() => Course, (course) => course.sections)
+  @JoinColumn({ name: 'course_id' })
+  public course: Course;
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: One-to-many relationship with Lesson entity
+   */
+  @OneToMany(() => Lesson, (lesson) => lesson.section)
+  public lessons: Lesson[];
+}

--- a/packages/postgres/src/migrations/1762165958622-CreateCoursesSectionsLessonsTables.ts
+++ b/packages/postgres/src/migrations/1762165958622-CreateCoursesSectionsLessonsTables.ts
@@ -1,0 +1,120 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { DatabaseCreateForeignKey, DatabaseCreateTable } from './utils';
+
+export class CreateCoursesSectionsLessonsTables1762165958622
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create courses table
+    await DatabaseCreateTable(queryRunner, 'courses', [
+      {
+        name: 'instructor_id',
+        type: 'uuid',
+        isNullable: false,
+      },
+      {
+        name: 'title',
+        type: 'varchar',
+        length: '255',
+        isNullable: false,
+      },
+      {
+        name: 'description',
+        type: 'text',
+        isNullable: true,
+      },
+      {
+        name: 'status',
+        type: 'varchar',
+        length: '50',
+        isNullable: false,
+        default: "'DRAFT'",
+      },
+    ]);
+
+    // Create foreign key from courses.instructor_id to instructors.id
+    await DatabaseCreateForeignKey(
+      queryRunner,
+      'courses',
+      'instructors',
+      'instructor_id',
+    );
+
+    // Create sections table
+    await DatabaseCreateTable(queryRunner, 'sections', [
+      {
+        name: 'course_id',
+        type: 'uuid',
+        isNullable: false,
+      },
+      {
+        name: 'title',
+        type: 'varchar',
+        length: '255',
+        isNullable: false,
+      },
+      {
+        name: 'order_index',
+        type: 'integer',
+        isNullable: false,
+        default: 0,
+      },
+    ]);
+
+    // Create foreign key from sections.course_id to courses.id
+    await DatabaseCreateForeignKey(
+      queryRunner,
+      'sections',
+      'courses',
+      'course_id',
+    );
+
+    // Create lessons table
+    await DatabaseCreateTable(queryRunner, 'lessons', [
+      {
+        name: 'section_id',
+        type: 'uuid',
+        isNullable: false,
+      },
+      {
+        name: 'title',
+        type: 'varchar',
+        length: '255',
+        isNullable: false,
+      },
+      {
+        name: 'content_url',
+        type: 'text',
+        isNullable: true,
+      },
+    ]);
+
+    // Create foreign key from lessons.section_id to sections.id
+    await DatabaseCreateForeignKey(
+      queryRunner,
+      'lessons',
+      'sections',
+      'section_id',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop lessons table (drop foreign key first, then table)
+    await queryRunner.query(
+      `ALTER TABLE "lessons" DROP CONSTRAINT IF EXISTS "FK_lessons_sections"`,
+    );
+    await queryRunner.dropTable('lessons');
+
+    // Drop sections table
+    await queryRunner.query(
+      `ALTER TABLE "sections" DROP CONSTRAINT IF EXISTS "FK_sections_courses"`,
+    );
+    await queryRunner.dropTable('sections');
+
+    // Drop courses table
+    await queryRunner.query(
+      `ALTER TABLE "courses" DROP CONSTRAINT IF EXISTS "FK_courses_instructors"`,
+    );
+    await queryRunner.dropTable('courses');
+  }
+}


### PR DESCRIPTION
## 📋 Task Description

This PR implements database schema changes for courses, sections, and lessons tables as defined in issue #2.

## ✅ Changes Made

### Enums
- ✅ Created `CoursesStatusEnum` with proper UPPER_SNAKE_CASE values:
  - DRAFT
  - REVIEW
  - PUBLISHED
  - ARCHIVED
  - DELETED

### Migration
- ✅ Created migration `1762165958622-CreateCoursesSectionsLessonsTables.ts`
  - Creates `courses` table with instructor_id FK, title, description, and status
  - Creates `sections` table with course_id FK, title, and order_index
  - Creates `lessons` table with section_id FK, title, and content_url
  - All tables include proper foreign keys with CASCADE delete
  - Migration tested with run/revert cycle (twice as required)

### Entities
- ✅ Created `Course` entity with relationships to Instructor and Section
- ✅ Created `Section` entity with relationships to Course and Lesson
- ✅ Created `Lesson` entity with relationship to Section
- ✅ Updated `Instructor` entity to include reverse relationship to Course
- ✅ All entities include proper JSDoc documentation

### Documentation
- ✅ Entity documentation includes TABLE-NAME, TABLE-DESCRIPTION, TABLE-IMPORTANT-CONSTRAINTS, and TABLE-RELATIONSHIPS
- ✅ Column documentation includes COLUMN-DESCRIPTION for each field
- ✅ Relationship documentation includes RELATIONSHIP-DESCRIPTION

## 🧪 Testing

- ✅ Migration run successful
- ✅ Migration revert successful (tested twice)
- ✅ TypeScript builds passing for both `@repo/enums` and `@repo/postgres`
- ✅ Linting passing for all modified packages
- ✅ No conflicts with existing migrations

## 📁 Files Changed

- `packages/enums/src/courses-status.enum.ts` (new)
- `packages/enums/src/index.ts` (updated)
- `packages/postgres/src/migrations/1762165958622-CreateCoursesSectionsLessonsTables.ts` (new)
- `packages/postgres/src/entities/course.entity.ts` (new)
- `packages/postgres/src/entities/section.entity.ts` (new)
- `packages/postgres/src/entities/lesson.entity.ts` (new)
- `packages/postgres/src/entities/instructor.entity.ts` (updated)
- `packages/postgres/src/entities/index.ts` (updated)

## 🔍 Implementation Notes

- All enum values follow UPPER_SNAKE_CASE convention as per `@enums` rule
- Entities follow TypeORM best practices with proper decorators
- Foreign key column names explicitly specified to avoid auto-generated naming conflicts
- Migration follows the established pattern from existing migrations
- All tables include standard BaseEntity fields (id, created_at, updated_at, deleted_at)

Closes #2