### PR TITLE
feat: add enrollments, course_reviews, and progress tables

### DIFF
--- a/packages/postgres/src/entities/course-review.entity.ts
+++ b/packages/postgres/src/entities/course-review.entity.ts
@@ -1,0 +1,74 @@
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseEntity } from './base.entity';
+import { User } from './user.entity';
+import { Course } from './course.entity';
+
+/**
+ * TABLE-NAME: course_reviews
+ * TABLE-DESCRIPTION: Stores student feedback, ratings, and text reviews for courses
+ * TABLE-IMPORTANT-CONSTRAINTS:
+ *   - user_id is a foreign key referencing users.id with CASCADE on delete
+ *   - course_id is a foreign key referencing courses.id with CASCADE on delete
+ *   - rating is a smallint between 1 and 5
+ *   - review_text is optional text field
+ *   - inherits id (UUID), createdAt, updatedAt, and deletedAt from BaseEntity
+ * TABLE-RELATIONSHIPS:
+ *   - Many-to-one relationship with User (each review belongs to one user)
+ *   - Many-to-one relationship with Course (each review belongs to one course)
+ */
+@Entity('course_reviews')
+export class CourseReview extends BaseEntity {
+  /**
+   * COLUMN-DESCRIPTION: Foreign key referencing the user who wrote the review
+   */
+  @Column({
+    type: 'uuid',
+    name: 'user_id',
+    nullable: false,
+  })
+  public userId: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Foreign key referencing the course being reviewed
+   */
+  @Column({
+    type: 'uuid',
+    name: 'course_id',
+    nullable: false,
+  })
+  public courseId: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Rating score from 1 to 5 stars
+   */
+  @Column({
+    type: 'smallint',
+    name: 'rating',
+    nullable: false,
+  })
+  public rating: number;
+
+  /**
+   * COLUMN-DESCRIPTION: Optional text review providing detailed feedback
+   */
+  @Column({
+    type: 'text',
+    name: 'review_text',
+    nullable: true,
+  })
+  public reviewText: string | null;
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: Many-to-one relationship with User entity
+   */
+  @ManyToOne(() => User, (user) => user.courseReviews)
+  @JoinColumn({ name: 'user_id' })
+  public user: User;
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: Many-to-one relationship with Course entity
+   */
+  @ManyToOne(() => Course, (course) => course.courseReviews)
+  @JoinColumn({ name: 'course_id' })
+  public course: Course;
+}

--- a/packages/postgres/src/entities/course.entity.ts
+++ b/packages/postgres/src/entities/course.entity.ts
@@ -3,6 +3,8 @@ import { BaseEntity } from './base.entity';
 import { Instructor } from './instructor.entity';
 import { Section } from './section.entity';
 import { CoursesStatusEnum } from '@repo/enums';
+import { Enrollment } from './enrollment.entity';
+import { CourseReview } from './course-review.entity';
 
 /**
  * TABLE-NAME: courses
@@ -16,6 +18,8 @@ import { CoursesStatusEnum } from '@repo/enums';
  * TABLE-RELATIONSHIPS:
  *   - Many-to-one relationship with Instructor (each course belongs to one instructor)
  *   - One-to-many relationship with Section (a course can have multiple sections)
+ *   - One-to-many relationship with Enrollment (a course can have multiple enrollments)
+ *   - One-to-many relationship with CourseReview (a course can have multiple reviews)
  */
 @Entity('courses')
 export class Course extends BaseEntity {
@@ -74,4 +78,16 @@ export class Course extends BaseEntity {
    */
   @OneToMany(() => Section, (section) => section.course)
   public sections: Section[];
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: One-to-many relationship with Enrollment entity
+   */
+  @OneToMany(() => Enrollment, (enrollment) => enrollment.course)
+  public enrollments: Enrollment[];
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: One-to-many relationship with CourseReview entity
+   */
+  @OneToMany(() => CourseReview, (courseReview) => courseReview.course)
+  public courseReviews: CourseReview[];
 }

--- a/packages/postgres/src/entities/enrollment.entity.ts
+++ b/packages/postgres/src/entities/enrollment.entity.ts
@@ -1,0 +1,95 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  Unique,
+} from 'typeorm';
+import { BaseEntity } from './base.entity';
+import { User } from './user.entity';
+import { Course } from './course.entity';
+import { Progress } from './progress.entity';
+
+/**
+ * TABLE-NAME: enrollments
+ * TABLE-DESCRIPTION: Records a student's active registration in a course. Serves as a junction table linking users to courses.
+ * TABLE-IMPORTANT-CONSTRAINTS:
+ *   - Composite unique key on (user_id, course_id) prevents duplicate enrollments
+ *   - user_id is a foreign key referencing users.id with CASCADE on delete
+ *   - course_id is a foreign key referencing courses.id with CASCADE on delete
+ *   - completion_status is stored as numeric(5,2) representing percentage (0.00 to 100.00)
+ *   - enrollment_date defaults to current timestamp
+ *   - inherits id (UUID), createdAt, updatedAt, and deletedAt from BaseEntity
+ * TABLE-RELATIONSHIPS:
+ *   - Many-to-one relationship with User (each enrollment belongs to one user)
+ *   - Many-to-one relationship with Course (each enrollment belongs to one course)
+ *   - One-to-many relationship with Progress (an enrollment can have multiple progress records)
+ */
+@Entity('enrollments')
+@Unique('UQ_enrollments_user_course', ['userId', 'courseId'])
+export class Enrollment extends BaseEntity {
+  /**
+   * COLUMN-DESCRIPTION: Foreign key referencing the user who is enrolled in the course
+   */
+  @Column({
+    type: 'uuid',
+    name: 'user_id',
+    nullable: false,
+  })
+  public userId: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Foreign key referencing the course the user is enrolled in
+   */
+  @Column({
+    type: 'uuid',
+    name: 'course_id',
+    nullable: false,
+  })
+  public courseId: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Date and time when the user enrolled in the course
+   */
+  @Column({
+    type: 'timestamptz',
+    name: 'enrollment_date',
+    nullable: false,
+    default: () => 'now()',
+  })
+  public enrollmentDate: Date;
+
+  /**
+   * COLUMN-DESCRIPTION: Percentage of course completion (0.00 to 100.00)
+   */
+  @Column({
+    type: 'numeric',
+    name: 'completion_status',
+    nullable: false,
+    precision: 5,
+    scale: 2,
+    default: 0,
+  })
+  public completionStatus: number;
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: Many-to-one relationship with User entity
+   */
+  @ManyToOne(() => User, (user) => user.enrollments)
+  @JoinColumn({ name: 'user_id' })
+  public user: User;
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: Many-to-one relationship with Course entity
+   */
+  @ManyToOne(() => Course, (course) => course.enrollments)
+  @JoinColumn({ name: 'course_id' })
+  public course: Course;
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: One-to-many relationship with Progress entity
+   */
+  @OneToMany(() => Progress, (progress) => progress.enrollment)
+  public progresses: Progress[];
+}

--- a/packages/postgres/src/entities/index.ts
+++ b/packages/postgres/src/entities/index.ts
@@ -1,10 +1,33 @@
 import { BaseEntity } from './base.entity';
 import { Course } from './course.entity';
+import { CourseReview } from './course-review.entity';
+import { Enrollment } from './enrollment.entity';
 import { Instructor } from './instructor.entity';
 import { Lesson } from './lesson.entity';
+import { Progress } from './progress.entity';
 import { Section } from './section.entity';
 import { User } from './user.entity';
 
-export const entities = [BaseEntity, User, Instructor, Course, Section, Lesson];
+export const entities = [
+  BaseEntity,
+  User,
+  Instructor,
+  Course,
+  Section,
+  Lesson,
+  Enrollment,
+  CourseReview,
+  Progress,
+];
 
-export { BaseEntity, User, Instructor, Course, Section, Lesson };
+export {
+  BaseEntity,
+  User,
+  Instructor,
+  Course,
+  Section,
+  Lesson,
+  Enrollment,
+  CourseReview,
+  Progress,
+};

--- a/packages/postgres/src/entities/lesson.entity.ts
+++ b/packages/postgres/src/entities/lesson.entity.ts
@@ -1,6 +1,7 @@
-import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 import { BaseEntity } from './base.entity';
 import { Section } from './section.entity';
+import { Progress } from './progress.entity';
 
 /**
  * TABLE-NAME: lessons
@@ -12,6 +13,7 @@ import { Section } from './section.entity';
  *   - inherits id (UUID), createdAt, updatedAt, and deletedAt from BaseEntity
  * TABLE-RELATIONSHIPS:
  *   - Many-to-one relationship with Section (each lesson belongs to one section)
+ *   - One-to-many relationship with Progress (a lesson can have multiple progress records)
  */
 @Entity('lessons')
 export class Lesson extends BaseEntity {
@@ -52,4 +54,10 @@ export class Lesson extends BaseEntity {
   @ManyToOne(() => Section, (section) => section.lessons)
   @JoinColumn({ name: 'section_id' })
   public section: Section;
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: One-to-many relationship with Progress entity
+   */
+  @OneToMany(() => Progress, (progress) => progress.lesson)
+  public progresses: Progress[];
 }

--- a/packages/postgres/src/entities/progress.entity.ts
+++ b/packages/postgres/src/entities/progress.entity.ts
@@ -1,0 +1,76 @@
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseEntity } from './base.entity';
+import { Enrollment } from './enrollment.entity';
+import { Lesson } from './lesson.entity';
+
+/**
+ * TABLE-NAME: progress
+ * TABLE-DESCRIPTION: Tracks a student's completion status for each lesson within an enrollment
+ * TABLE-IMPORTANT-CONSTRAINTS:
+ *   - enrollment_id is a foreign key referencing enrollments.id with CASCADE on delete
+ *   - lesson_id is a foreign key referencing lessons.id with CASCADE on delete
+ *   - is_completed is a boolean flag indicating completion status
+ *   - last_watched_time stores the last position watched in seconds
+ *   - inherits id (UUID), createdAt, updatedAt, and deletedAt from BaseEntity
+ * TABLE-RELATIONSHIPS:
+ *   - Many-to-one relationship with Enrollment (each progress record belongs to one enrollment)
+ *   - Many-to-one relationship with Lesson (each progress record belongs to one lesson)
+ */
+@Entity('progress')
+export class Progress extends BaseEntity {
+  /**
+   * COLUMN-DESCRIPTION: Foreign key referencing the enrollment this progress belongs to
+   */
+  @Column({
+    type: 'uuid',
+    name: 'enrollment_id',
+    nullable: false,
+  })
+  public enrollmentId: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Foreign key referencing the lesson being tracked
+   */
+  @Column({
+    type: 'uuid',
+    name: 'lesson_id',
+    nullable: false,
+  })
+  public lessonId: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Boolean flag indicating whether the lesson has been completed
+   */
+  @Column({
+    type: 'boolean',
+    name: 'is_completed',
+    nullable: false,
+    default: false,
+  })
+  public isCompleted: boolean;
+
+  /**
+   * COLUMN-DESCRIPTION: Last watched position in the lesson content (in seconds)
+   */
+  @Column({
+    type: 'integer',
+    name: 'last_watched_time',
+    nullable: true,
+    default: 0,
+  })
+  public lastWatchedTime: number | null;
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: Many-to-one relationship with Enrollment entity
+   */
+  @ManyToOne(() => Enrollment, (enrollment) => enrollment.progresses)
+  @JoinColumn({ name: 'enrollment_id' })
+  public enrollment: Enrollment;
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: Many-to-one relationship with Lesson entity
+   */
+  @ManyToOne(() => Lesson, (lesson) => lesson.progresses)
+  @JoinColumn({ name: 'lesson_id' })
+  public lesson: Lesson;
+}

--- a/packages/postgres/src/entities/user.entity.ts
+++ b/packages/postgres/src/entities/user.entity.ts
@@ -1,6 +1,8 @@
-import { Column, Entity, OneToOne } from 'typeorm';
+import { Column, Entity, OneToMany, OneToOne } from 'typeorm';
 import { BaseEntity } from './base.entity';
 import { Instructor } from './instructor.entity';
+import { Enrollment } from './enrollment.entity';
+import { CourseReview } from './course-review.entity';
 
 /**
  * TABLE-NAME: users
@@ -45,4 +47,16 @@ export class User extends BaseEntity {
     nullable: true,
   })
   public instructor?: Instructor;
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: One-to-many relationship with Enrollment entity
+   */
+  @OneToMany(() => Enrollment, (enrollment) => enrollment.user)
+  public enrollments: Enrollment[];
+
+  /**
+   * RELATIONSHIP-DESCRIPTION: One-to-many relationship with CourseReview entity
+   */
+  @OneToMany(() => CourseReview, (courseReview) => courseReview.user)
+  public courseReviews: CourseReview[];
 }

--- a/packages/postgres/src/migrations/1762166557412-CreateEnrollmentsReviewsProgressTables.ts
+++ b/packages/postgres/src/migrations/1762166557412-CreateEnrollmentsReviewsProgressTables.ts
@@ -1,0 +1,166 @@
+import { MigrationInterface, QueryRunner, TableUnique } from 'typeorm';
+import { DatabaseCreateForeignKey, DatabaseCreateTable } from './utils';
+
+export class CreateEnrollmentsReviewsProgressTables1762166557412
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create enrollments table
+    await DatabaseCreateTable(queryRunner, 'enrollments', [
+      {
+        name: 'user_id',
+        type: 'uuid',
+        isNullable: false,
+      },
+      {
+        name: 'course_id',
+        type: 'uuid',
+        isNullable: false,
+      },
+      {
+        name: 'enrollment_date',
+        type: 'timestamptz',
+        isNullable: false,
+        default: 'now()',
+      },
+      {
+        name: 'completion_status',
+        type: 'numeric',
+        precision: 5,
+        scale: 2,
+        isNullable: false,
+        default: 0,
+      },
+    ]);
+
+    // Create composite unique key for enrollments (user_id, course_id)
+    await queryRunner.createUniqueConstraint(
+      'enrollments',
+      new TableUnique({
+        name: 'UQ_enrollments_user_course',
+        columnNames: ['user_id', 'course_id'],
+      }),
+    );
+
+    // Create foreign keys for enrollments
+    await DatabaseCreateForeignKey(
+      queryRunner,
+      'enrollments',
+      'users',
+      'user_id',
+    );
+    await DatabaseCreateForeignKey(
+      queryRunner,
+      'enrollments',
+      'courses',
+      'course_id',
+    );
+
+    // Create course_reviews table
+    await DatabaseCreateTable(queryRunner, 'course_reviews', [
+      {
+        name: 'user_id',
+        type: 'uuid',
+        isNullable: false,
+      },
+      {
+        name: 'course_id',
+        type: 'uuid',
+        isNullable: false,
+      },
+      {
+        name: 'rating',
+        type: 'smallint',
+        isNullable: false,
+      },
+      {
+        name: 'review_text',
+        type: 'text',
+        isNullable: true,
+      },
+    ]);
+
+    // Create foreign keys for course_reviews
+    await DatabaseCreateForeignKey(
+      queryRunner,
+      'course_reviews',
+      'users',
+      'user_id',
+    );
+    await DatabaseCreateForeignKey(
+      queryRunner,
+      'course_reviews',
+      'courses',
+      'course_id',
+    );
+
+    // Create progress table
+    await DatabaseCreateTable(queryRunner, 'progress', [
+      {
+        name: 'enrollment_id',
+        type: 'uuid',
+        isNullable: false,
+      },
+      {
+        name: 'lesson_id',
+        type: 'uuid',
+        isNullable: false,
+      },
+      {
+        name: 'is_completed',
+        type: 'boolean',
+        isNullable: false,
+        default: false,
+      },
+      {
+        name: 'last_watched_time',
+        type: 'integer',
+        isNullable: true,
+        default: 0,
+      },
+    ]);
+
+    // Create foreign keys for progress
+    await DatabaseCreateForeignKey(
+      queryRunner,
+      'progress',
+      'enrollments',
+      'enrollment_id',
+    );
+    await DatabaseCreateForeignKey(
+      queryRunner,
+      'progress',
+      'lessons',
+      'lesson_id',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop progress table (drop foreign keys first, then table)
+    await queryRunner.query(
+      `ALTER TABLE "progress" DROP CONSTRAINT IF EXISTS "FK_progress_enrollments"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "progress" DROP CONSTRAINT IF EXISTS "FK_progress_lessons"`,
+    );
+    await queryRunner.dropTable('progress');
+
+    // Drop course_reviews table
+    await queryRunner.query(
+      `ALTER TABLE "course_reviews" DROP CONSTRAINT IF EXISTS "FK_course_reviews_users"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "course_reviews" DROP CONSTRAINT IF EXISTS "FK_course_reviews_courses"`,
+    );
+    await queryRunner.dropTable('course_reviews');
+
+    // Drop enrollments table
+    await queryRunner.query(
+      `ALTER TABLE "enrollments" DROP CONSTRAINT IF EXISTS "FK_enrollments_users"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "enrollments" DROP CONSTRAINT IF EXISTS "FK_enrollments_courses"`,
+    );
+    await queryRunner.dropTable('enrollments');
+  }
+}


### PR DESCRIPTION
- Created migration for enrollments, course_reviews, and progress tables
- Added Enrollment, CourseReview, and Progress entities
- Updated User, Course, and Lesson entities with reverse relationships
- All entities follow TypeORM conventions and postgres package standards
- Migration tested with run and revert cycles
- TypeScript builds and lints successfully

Closes #3