### PR TITLE
feat(postgres): add ReviewFeedback domain service

### DIFF
--- a/packages/backend-modules/postgres/src/services/index.ts
+++ b/packages/backend-modules/postgres/src/services/index.ts
@@ -1,11 +1,18 @@
 import { UserService } from './user.service';
 import { CourseManagementService } from './course-management.service';
 import { LearningProgressService } from './learning-progress.service';
+import { ReviewFeedbackService } from './review-feedback.service';
 
 export const services = [
   UserService,
   CourseManagementService,
   LearningProgressService,
+  ReviewFeedbackService,
 ];
 
-export { UserService, CourseManagementService, LearningProgressService };
+export {
+  UserService,
+  CourseManagementService,
+  LearningProgressService,
+  ReviewFeedbackService,
+};

--- a/packages/backend-modules/postgres/src/services/review-feedback.service.ts
+++ b/packages/backend-modules/postgres/src/services/review-feedback.service.ts
@@ -1,0 +1,261 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, FindOptionsRelations } from 'typeorm';
+import { CourseReview } from '@repo/postgres/entities/course-review.entity';
+import { User } from '@repo/postgres/entities/user.entity';
+import { Course } from '@repo/postgres/entities/course.entity';
+import { Enrollment } from '@repo/postgres/entities/enrollment.entity';
+import { IPaginate } from '@repo/dtos/pagination';
+import { SortEnum } from '@repo/enums';
+import { paginate } from './utils/paginate';
+import {
+  CustomError,
+  COURSE_REVIEW_NOT_FOUND,
+  COURSE_REVIEW_USER_ID_REQUIRED,
+  COURSE_REVIEW_COURSE_ID_REQUIRED,
+  COURSE_REVIEW_RATING_REQUIRED,
+  COURSE_REVIEW_USER_NOT_FOUND,
+  COURSE_REVIEW_COURSE_NOT_FOUND,
+  COURSE_REVIEW_ALREADY_EXISTS,
+  COURSE_REVIEW_INVALID_RATING,
+  COURSE_REVIEW_NO_ENROLLMENT,
+} from '@repo/http-errors';
+
+@Injectable()
+export class ReviewFeedbackService {
+  constructor(
+    @InjectRepository(CourseReview)
+    private readonly courseReviewRepository: Repository<CourseReview>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(Course)
+    private readonly courseRepository: Repository<Course>,
+    @InjectRepository(Enrollment)
+    private readonly enrollmentRepository: Repository<Enrollment>,
+  ) {}
+
+  public async createCourseReview(input: {
+    userId: string;
+    courseId: string;
+    rating: number;
+    reviewText?: string;
+  }): Promise<CourseReview> {
+    const { userId, courseId, rating, reviewText } = input;
+
+    if (!userId) {
+      throw new CustomError(COURSE_REVIEW_USER_ID_REQUIRED);
+    }
+
+    if (!courseId) {
+      throw new CustomError(COURSE_REVIEW_COURSE_ID_REQUIRED);
+    }
+
+    if (rating === undefined || rating === null) {
+      throw new CustomError(COURSE_REVIEW_RATING_REQUIRED);
+    }
+
+    if (rating < 1 || rating > 5 || !Number.isInteger(rating)) {
+      throw new CustomError(COURSE_REVIEW_INVALID_RATING);
+    }
+
+    const user = await this.userRepository.findOne({
+      where: { id: userId },
+    });
+
+    if (!user) {
+      throw new CustomError(COURSE_REVIEW_USER_NOT_FOUND);
+    }
+
+    const course = await this.courseRepository.findOne({
+      where: { id: courseId },
+    });
+
+    if (!course) {
+      throw new CustomError(COURSE_REVIEW_COURSE_NOT_FOUND);
+    }
+
+    const enrollment = await this.enrollmentRepository.findOne({
+      where: { userId, courseId },
+    });
+
+    if (!enrollment) {
+      throw new CustomError(COURSE_REVIEW_NO_ENROLLMENT);
+    }
+
+    const existingReview = await this.courseReviewRepository.findOne({
+      where: { userId, courseId },
+    });
+
+    if (existingReview) {
+      throw new CustomError(COURSE_REVIEW_ALREADY_EXISTS);
+    }
+
+    const courseReview = this.courseReviewRepository.create({
+      userId,
+      courseId,
+      rating,
+      reviewText: reviewText || null,
+    });
+
+    const savedReview = await this.courseReviewRepository.save(courseReview);
+    return savedReview;
+  }
+
+  public async findCourseReviewById(input: {
+    reviewId: string;
+    returnError?: boolean;
+    relations?: FindOptionsRelations<CourseReview>;
+  }): Promise<CourseReview | undefined> {
+    const { reviewId, returnError, relations } = input;
+
+    if (!reviewId) {
+      if (returnError) {
+        throw new CustomError(COURSE_REVIEW_NOT_FOUND);
+      } else {
+        return undefined;
+      }
+    }
+
+    const review = await this.courseReviewRepository.findOne({
+      where: { id: reviewId },
+      relations,
+    });
+
+    if (!review && returnError) {
+      throw new CustomError(COURSE_REVIEW_NOT_FOUND);
+    }
+
+    return review;
+  }
+
+  public async updateCourseReview(input: {
+    reviewId: string;
+    rating?: number;
+    reviewText?: string;
+  }): Promise<CourseReview> {
+    const { reviewId, rating, reviewText } = input;
+
+    const review = await this.findCourseReviewById({
+      reviewId,
+      returnError: true,
+    });
+
+    if (!review) {
+      throw new CustomError(COURSE_REVIEW_NOT_FOUND);
+    }
+
+    const updateValue: Partial<CourseReview> = {};
+
+    if (rating !== undefined) {
+      if (rating < 1 || rating > 5 || !Number.isInteger(rating)) {
+        throw new CustomError(COURSE_REVIEW_INVALID_RATING);
+      }
+      updateValue.rating = rating;
+    }
+
+    if (reviewText !== undefined) {
+      updateValue.reviewText = reviewText || null;
+    }
+
+    if (Object.keys(updateValue).length > 0) {
+      await this.courseReviewRepository.update({ id: reviewId }, updateValue);
+    }
+
+    return (await this.findCourseReviewById({
+      reviewId,
+      returnError: true,
+    })) as CourseReview;
+  }
+
+  public async deleteCourseReview(input: { reviewId: string }): Promise<void> {
+    const { reviewId } = input;
+
+    const review = await this.findCourseReviewById({
+      reviewId,
+      returnError: true,
+    });
+
+    if (!review) {
+      throw new CustomError(COURSE_REVIEW_NOT_FOUND);
+    }
+
+    await review.softRemove();
+  }
+
+  public async findCourseReviews(
+    options: {
+      page?: number;
+      limit?: number;
+      userId?: string;
+      courseId?: string;
+      minRating?: number;
+      maxRating?: number;
+      sort?: string;
+      sortType?: SortEnum;
+    } = {},
+  ): Promise<IPaginate<CourseReview>> {
+    const {
+      page,
+      limit,
+      userId,
+      courseId,
+      minRating,
+      maxRating,
+      sort,
+      sortType,
+    } = options;
+
+    const queryBuilder =
+      this.courseReviewRepository.createQueryBuilder('courseReview');
+
+    if (userId) {
+      queryBuilder.andWhere('courseReview.userId = :userId', { userId });
+    }
+
+    if (courseId) {
+      queryBuilder.andWhere('courseReview.courseId = :courseId', { courseId });
+    }
+
+    if (minRating !== undefined) {
+      queryBuilder.andWhere('courseReview.rating >= :minRating', { minRating });
+    }
+
+    if (maxRating !== undefined) {
+      queryBuilder.andWhere('courseReview.rating <= :maxRating', { maxRating });
+    }
+
+    if (sort && sortType) {
+      queryBuilder.orderBy(`courseReview.${sort}`, sortType);
+    } else {
+      queryBuilder.orderBy('courseReview.createdAt', SortEnum.DESC);
+    }
+
+    return await paginate(queryBuilder, limit, page);
+  }
+
+  public async findCourseReviewByUserAndCourse(input: {
+    userId: string;
+    courseId: string;
+    returnError?: boolean;
+  }): Promise<CourseReview | undefined> {
+    const { userId, courseId, returnError } = input;
+
+    if (!userId || !courseId) {
+      if (returnError) {
+        throw new CustomError(COURSE_REVIEW_NOT_FOUND);
+      } else {
+        return undefined;
+      }
+    }
+
+    const review = await this.courseReviewRepository.findOne({
+      where: { userId, courseId },
+    });
+
+    if (!review && returnError) {
+      throw new CustomError(COURSE_REVIEW_NOT_FOUND);
+    }
+
+    return review;
+  }
+}

--- a/packages/backend-modules/postgres/src/services/review-feedback.test/methods/create-course-review.test.ts
+++ b/packages/backend-modules/postgres/src/services/review-feedback.test/methods/create-course-review.test.ts
@@ -1,0 +1,324 @@
+import {
+  CustomError,
+  COURSE_REVIEW_USER_ID_REQUIRED,
+  COURSE_REVIEW_COURSE_ID_REQUIRED,
+  COURSE_REVIEW_RATING_REQUIRED,
+  COURSE_REVIEW_USER_NOT_FOUND,
+  COURSE_REVIEW_COURSE_NOT_FOUND,
+  COURSE_REVIEW_NO_ENROLLMENT,
+  COURSE_REVIEW_ALREADY_EXISTS,
+  COURSE_REVIEW_INVALID_RATING,
+} from '@repo/http-errors';
+import { TestManager } from '../../../test-manager.test';
+import { ReviewFeedbackService } from '../../review-feedback.service';
+import { UserService } from '../../user.service';
+import { CourseManagementService } from '../../course-management.service';
+import { LearningProgressService } from '../../learning-progress.service';
+import { Instructor } from '@repo/postgres/entities/instructor.entity';
+import { faker } from '@faker-js/faker';
+
+describe('ReviewFeedbackService - createCourseReview', () => {
+  beforeAll(async () => {
+    await TestManager.beforeAll();
+  });
+
+  afterAll(async () => {
+    await TestManager.afterAll();
+  });
+
+  beforeEach(async () => {
+    await TestManager.beforeEach();
+  });
+
+  it('should create a new course review with valid input', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    const rating = 5;
+    const reviewText = faker.lorem.paragraph();
+
+    const actualResult = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating,
+      reviewText,
+    });
+
+    expect(actualResult.userId).toBe(studentUser.id);
+    expect(actualResult.courseId).toBe(course.id);
+    expect(actualResult.rating).toBe(rating);
+    expect(actualResult.reviewText).toBe(reviewText);
+    expect(actualResult.id).toBeDefined();
+  });
+
+  it('should throw COURSE_REVIEW_USER_ID_REQUIRED when userId is not provided', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+
+    await expect(
+      reviewFeedbackService.createCourseReview({
+        userId: '',
+        courseId: faker.string.uuid(),
+        rating: 5,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_USER_ID_REQUIRED));
+  });
+
+  it('should throw COURSE_REVIEW_COURSE_ID_REQUIRED when courseId is not provided', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+
+    await expect(
+      reviewFeedbackService.createCourseReview({
+        userId: faker.string.uuid(),
+        courseId: '',
+        rating: 5,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_COURSE_ID_REQUIRED));
+  });
+
+  it('should throw COURSE_REVIEW_RATING_REQUIRED when rating is not provided', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+
+    await expect(
+      reviewFeedbackService.createCourseReview({
+        userId: faker.string.uuid(),
+        courseId: faker.string.uuid(),
+        rating: undefined as any,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_RATING_REQUIRED));
+  });
+
+  it('should throw COURSE_REVIEW_INVALID_RATING when rating is less than 1', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+
+    await expect(
+      reviewFeedbackService.createCourseReview({
+        userId: faker.string.uuid(),
+        courseId: faker.string.uuid(),
+        rating: 0,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_INVALID_RATING));
+  });
+
+  it('should throw COURSE_REVIEW_INVALID_RATING when rating is greater than 5', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+
+    await expect(
+      reviewFeedbackService.createCourseReview({
+        userId: faker.string.uuid(),
+        courseId: faker.string.uuid(),
+        rating: 6,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_INVALID_RATING));
+  });
+
+  it('should throw COURSE_REVIEW_INVALID_RATING when rating is not an integer', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+
+    await expect(
+      reviewFeedbackService.createCourseReview({
+        userId: faker.string.uuid(),
+        courseId: faker.string.uuid(),
+        rating: 3.5,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_INVALID_RATING));
+  });
+
+  it('should throw COURSE_REVIEW_USER_NOT_FOUND when user does not exist', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+
+    await expect(
+      reviewFeedbackService.createCourseReview({
+        userId: faker.string.uuid(),
+        courseId: faker.string.uuid(),
+        rating: 5,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_USER_NOT_FOUND));
+  });
+
+  it('should throw COURSE_REVIEW_COURSE_NOT_FOUND when course does not exist', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await expect(
+      reviewFeedbackService.createCourseReview({
+        userId: user.id,
+        courseId: faker.string.uuid(),
+        rating: 5,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_COURSE_NOT_FOUND));
+  });
+
+  it('should throw COURSE_REVIEW_NO_ENROLLMENT when user is not enrolled in course', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await expect(
+      reviewFeedbackService.createCourseReview({
+        userId: studentUser.id,
+        courseId: course.id,
+        rating: 5,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_NO_ENROLLMENT));
+  });
+
+  it('should throw COURSE_REVIEW_ALREADY_EXISTS when user has already reviewed the course', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating: 5,
+    });
+
+    await expect(
+      reviewFeedbackService.createCourseReview({
+        userId: studentUser.id,
+        courseId: course.id,
+        rating: 4,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_ALREADY_EXISTS));
+  });
+
+  it('should create a course review without review text', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    const actualResult = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating: 5,
+    });
+
+    expect(actualResult.reviewText).toBeNull();
+  });
+});

--- a/packages/backend-modules/postgres/src/services/review-feedback.test/methods/delete-course-review.test.ts
+++ b/packages/backend-modules/postgres/src/services/review-feedback.test/methods/delete-course-review.test.ts
@@ -1,0 +1,89 @@
+import { CustomError, COURSE_REVIEW_NOT_FOUND } from '@repo/http-errors';
+import { TestManager } from '../../../test-manager.test';
+import { ReviewFeedbackService } from '../../review-feedback.service';
+import { UserService } from '../../user.service';
+import { CourseManagementService } from '../../course-management.service';
+import { LearningProgressService } from '../../learning-progress.service';
+import { Instructor } from '@repo/postgres/entities/instructor.entity';
+import { faker } from '@faker-js/faker';
+
+describe('ReviewFeedbackService - deleteCourseReview', () => {
+  beforeAll(async () => {
+    await TestManager.beforeAll();
+  });
+
+  afterAll(async () => {
+    await TestManager.afterAll();
+  });
+
+  beforeEach(async () => {
+    await TestManager.beforeEach();
+  });
+
+  it('should delete a course review', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    const review = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating: 5,
+      reviewText: faker.lorem.paragraph(),
+    });
+
+    await reviewFeedbackService.deleteCourseReview({
+      reviewId: review.id,
+    });
+
+    const deletedReview = await reviewFeedbackService.findCourseReviewById({
+      reviewId: review.id,
+      returnError: false,
+    });
+
+    expect(deletedReview).toBeNull();
+  });
+
+  it('should throw COURSE_REVIEW_NOT_FOUND when review does not exist', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+
+    await expect(
+      reviewFeedbackService.deleteCourseReview({
+        reviewId: faker.string.uuid(),
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_NOT_FOUND));
+  });
+});
+

--- a/packages/backend-modules/postgres/src/services/review-feedback.test/methods/delete-course-review.test.ts
+++ b/packages/backend-modules/postgres/src/services/review-feedback.test/methods/delete-course-review.test.ts
@@ -86,4 +86,3 @@ describe('ReviewFeedbackService - deleteCourseReview', () => {
     ).rejects.toThrow(new CustomError(COURSE_REVIEW_NOT_FOUND));
   });
 });
-

--- a/packages/backend-modules/postgres/src/services/review-feedback.test/methods/find-course-review-by-id.test.ts
+++ b/packages/backend-modules/postgres/src/services/review-feedback.test/methods/find-course-review-by-id.test.ts
@@ -1,0 +1,120 @@
+import { CustomError, COURSE_REVIEW_NOT_FOUND } from '@repo/http-errors';
+import { TestManager } from '../../../test-manager.test';
+import { ReviewFeedbackService } from '../../review-feedback.service';
+import { UserService } from '../../user.service';
+import { CourseManagementService } from '../../course-management.service';
+import { LearningProgressService } from '../../learning-progress.service';
+import { Instructor } from '@repo/postgres/entities/instructor.entity';
+import { faker } from '@faker-js/faker';
+
+describe('ReviewFeedbackService - findCourseReviewById', () => {
+  beforeAll(async () => {
+    await TestManager.beforeAll();
+  });
+
+  afterAll(async () => {
+    await TestManager.afterAll();
+  });
+
+  beforeEach(async () => {
+    await TestManager.beforeEach();
+  });
+
+  it('should find a course review by id', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    const review = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating: 5,
+      reviewText: faker.lorem.paragraph(),
+    });
+
+    const actualResult = await reviewFeedbackService.findCourseReviewById({
+      reviewId: review.id,
+    });
+
+    expect(actualResult).toBeDefined();
+    expect(actualResult?.id).toBe(review.id);
+    expect(actualResult?.userId).toBe(studentUser.id);
+    expect(actualResult?.courseId).toBe(course.id);
+  });
+
+  it('should return undefined when review is not found and returnError is false', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+
+    const actualResult = await reviewFeedbackService.findCourseReviewById({
+      reviewId: faker.string.uuid(),
+      returnError: false,
+    });
+
+    expect(actualResult).toBeNull();
+  });
+
+  it('should throw COURSE_REVIEW_NOT_FOUND when review is not found and returnError is true', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+
+    await expect(
+      reviewFeedbackService.findCourseReviewById({
+        reviewId: faker.string.uuid(),
+        returnError: true,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_NOT_FOUND));
+  });
+
+  it('should return undefined when reviewId is empty and returnError is false', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+
+    const actualResult = await reviewFeedbackService.findCourseReviewById({
+      reviewId: '',
+      returnError: false,
+    });
+
+    expect(actualResult).toBeUndefined();
+  });
+
+  it('should throw COURSE_REVIEW_NOT_FOUND when reviewId is empty and returnError is true', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+
+    await expect(
+      reviewFeedbackService.findCourseReviewById({
+        reviewId: '',
+        returnError: true,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_NOT_FOUND));
+  });
+});

--- a/packages/backend-modules/postgres/src/services/review-feedback.test/methods/find-course-reviews.test.ts
+++ b/packages/backend-modules/postgres/src/services/review-feedback.test/methods/find-course-reviews.test.ts
@@ -1,0 +1,359 @@
+import { TestManager } from '../../../test-manager.test';
+import { ReviewFeedbackService } from '../../review-feedback.service';
+import { UserService } from '../../user.service';
+import { CourseManagementService } from '../../course-management.service';
+import { LearningProgressService } from '../../learning-progress.service';
+import { Instructor } from '@repo/postgres/entities/instructor.entity';
+import { faker } from '@faker-js/faker';
+
+describe('ReviewFeedbackService - findCourseReviews', () => {
+  beforeAll(async () => {
+    await TestManager.beforeAll();
+  });
+
+  afterAll(async () => {
+    await TestManager.afterAll();
+  });
+
+  beforeEach(async () => {
+    await TestManager.beforeEach();
+  });
+
+  it('should find all course reviews', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser1 = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const studentUser2 = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser1.id,
+      courseId: course.id,
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser2.id,
+      courseId: course.id,
+    });
+
+    await reviewFeedbackService.createCourseReview({
+      userId: studentUser1.id,
+      courseId: course.id,
+      rating: 5,
+    });
+
+    await reviewFeedbackService.createCourseReview({
+      userId: studentUser2.id,
+      courseId: course.id,
+      rating: 4,
+    });
+
+    const actualResult = await reviewFeedbackService.findCourseReviews();
+
+    expect(actualResult.items.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('should filter reviews by userId', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser1 = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const studentUser2 = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser1.id,
+      courseId: course.id,
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser2.id,
+      courseId: course.id,
+    });
+
+    await reviewFeedbackService.createCourseReview({
+      userId: studentUser1.id,
+      courseId: course.id,
+      rating: 5,
+    });
+
+    await reviewFeedbackService.createCourseReview({
+      userId: studentUser2.id,
+      courseId: course.id,
+      rating: 4,
+    });
+
+    const actualResult = await reviewFeedbackService.findCourseReviews({
+      userId: studentUser1.id,
+    });
+
+    expect(actualResult.items.length).toBeGreaterThanOrEqual(1);
+    actualResult.items.forEach((review) => {
+      expect(review.userId).toBe(studentUser1.id);
+    });
+  });
+
+  it('should filter reviews by courseId', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course1 = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const course2 = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course1.id,
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course2.id,
+    });
+
+    await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course1.id,
+      rating: 5,
+    });
+
+    await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course2.id,
+      rating: 4,
+    });
+
+    const actualResult = await reviewFeedbackService.findCourseReviews({
+      courseId: course1.id,
+    });
+
+    expect(actualResult.items.length).toBeGreaterThanOrEqual(1);
+    actualResult.items.forEach((review) => {
+      expect(review.courseId).toBe(course1.id);
+    });
+  });
+
+  it('should filter reviews by minRating', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser1 = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const studentUser2 = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser1.id,
+      courseId: course.id,
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser2.id,
+      courseId: course.id,
+    });
+
+    await reviewFeedbackService.createCourseReview({
+      userId: studentUser1.id,
+      courseId: course.id,
+      rating: 5,
+    });
+
+    await reviewFeedbackService.createCourseReview({
+      userId: studentUser2.id,
+      courseId: course.id,
+      rating: 2,
+    });
+
+    const actualResult = await reviewFeedbackService.findCourseReviews({
+      minRating: 4,
+    });
+
+    actualResult.items.forEach((review) => {
+      expect(review.rating).toBeGreaterThanOrEqual(4);
+    });
+  });
+
+  it('should filter reviews by maxRating', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser1 = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const studentUser2 = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser1.id,
+      courseId: course.id,
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser2.id,
+      courseId: course.id,
+    });
+
+    await reviewFeedbackService.createCourseReview({
+      userId: studentUser1.id,
+      courseId: course.id,
+      rating: 5,
+    });
+
+    await reviewFeedbackService.createCourseReview({
+      userId: studentUser2.id,
+      courseId: course.id,
+      rating: 2,
+    });
+
+    const actualResult = await reviewFeedbackService.findCourseReviews({
+      maxRating: 3,
+    });
+
+    actualResult.items.forEach((review) => {
+      expect(review.rating).toBeLessThanOrEqual(3);
+    });
+  });
+});

--- a/packages/backend-modules/postgres/src/services/review-feedback.test/methods/update-course-review.test.ts
+++ b/packages/backend-modules/postgres/src/services/review-feedback.test/methods/update-course-review.test.ts
@@ -407,4 +407,3 @@ describe('ReviewFeedbackService - updateCourseReview', () => {
     expect(actualResult.reviewText).toBeNull();
   });
 });
-

--- a/packages/backend-modules/postgres/src/services/review-feedback.test/methods/update-course-review.test.ts
+++ b/packages/backend-modules/postgres/src/services/review-feedback.test/methods/update-course-review.test.ts
@@ -1,0 +1,410 @@
+import {
+  CustomError,
+  COURSE_REVIEW_NOT_FOUND,
+  COURSE_REVIEW_INVALID_RATING,
+} from '@repo/http-errors';
+import { TestManager } from '../../../test-manager.test';
+import { ReviewFeedbackService } from '../../review-feedback.service';
+import { UserService } from '../../user.service';
+import { CourseManagementService } from '../../course-management.service';
+import { LearningProgressService } from '../../learning-progress.service';
+import { Instructor } from '@repo/postgres/entities/instructor.entity';
+import { faker } from '@faker-js/faker';
+
+describe('ReviewFeedbackService - updateCourseReview', () => {
+  beforeAll(async () => {
+    await TestManager.beforeAll();
+  });
+
+  afterAll(async () => {
+    await TestManager.afterAll();
+  });
+
+  beforeEach(async () => {
+    await TestManager.beforeEach();
+  });
+
+  it('should update a course review rating', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    const review = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating: 3,
+      reviewText: faker.lorem.paragraph(),
+    });
+
+    const newRating = 5;
+
+    const actualResult = await reviewFeedbackService.updateCourseReview({
+      reviewId: review.id,
+      rating: newRating,
+    });
+
+    expect(actualResult.rating).toBe(newRating);
+    expect(actualResult.id).toBe(review.id);
+  });
+
+  it('should update a course review text', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    const review = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating: 5,
+      reviewText: faker.lorem.paragraph(),
+    });
+
+    const newReviewText = 'Updated review text';
+
+    const actualResult = await reviewFeedbackService.updateCourseReview({
+      reviewId: review.id,
+      reviewText: newReviewText,
+    });
+
+    expect(actualResult.reviewText).toBe(newReviewText);
+    expect(actualResult.id).toBe(review.id);
+  });
+
+  it('should update both rating and review text', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    const review = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating: 3,
+      reviewText: faker.lorem.paragraph(),
+    });
+
+    const newRating = 5;
+    const newReviewText = 'Updated review text';
+
+    const actualResult = await reviewFeedbackService.updateCourseReview({
+      reviewId: review.id,
+      rating: newRating,
+      reviewText: newReviewText,
+    });
+
+    expect(actualResult.rating).toBe(newRating);
+    expect(actualResult.reviewText).toBe(newReviewText);
+  });
+
+  it('should throw COURSE_REVIEW_NOT_FOUND when review does not exist', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+
+    await expect(
+      reviewFeedbackService.updateCourseReview({
+        reviewId: faker.string.uuid(),
+        rating: 5,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_NOT_FOUND));
+  });
+
+  it('should throw COURSE_REVIEW_INVALID_RATING when rating is less than 1', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    const review = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating: 5,
+    });
+
+    await expect(
+      reviewFeedbackService.updateCourseReview({
+        reviewId: review.id,
+        rating: 0,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_INVALID_RATING));
+  });
+
+  it('should throw COURSE_REVIEW_INVALID_RATING when rating is greater than 5', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    const review = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating: 5,
+    });
+
+    await expect(
+      reviewFeedbackService.updateCourseReview({
+        reviewId: review.id,
+        rating: 6,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_INVALID_RATING));
+  });
+
+  it('should throw COURSE_REVIEW_INVALID_RATING when rating is not an integer', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    const review = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating: 5,
+    });
+
+    await expect(
+      reviewFeedbackService.updateCourseReview({
+        reviewId: review.id,
+        rating: 3.5,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_INVALID_RATING));
+  });
+
+  it('should set review text to null when empty string is provided', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    const review = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating: 5,
+      reviewText: faker.lorem.paragraph(),
+    });
+
+    const actualResult = await reviewFeedbackService.updateCourseReview({
+      reviewId: review.id,
+      reviewText: '',
+    });
+
+    expect(actualResult.reviewText).toBeNull();
+  });
+});
+

--- a/packages/backend-modules/postgres/src/services/review-feedback.test/rules/rule-01-enrollment-required.test.ts
+++ b/packages/backend-modules/postgres/src/services/review-feedback.test/rules/rule-01-enrollment-required.test.ts
@@ -1,0 +1,176 @@
+import { CustomError, COURSE_REVIEW_NO_ENROLLMENT } from '@repo/http-errors';
+import { TestManager } from '../../../test-manager.test';
+import { ReviewFeedbackService } from '../../review-feedback.service';
+import { UserService } from '../../user.service';
+import { CourseManagementService } from '../../course-management.service';
+import { LearningProgressService } from '../../learning-progress.service';
+import { Instructor } from '@repo/postgres/entities/instructor.entity';
+import { faker } from '@faker-js/faker';
+
+/**
+ * DOMAIN RULE 01: A user can only submit a Course Review if a corresponding Enrollment record exists
+ * (i.e., they must be actively enrolled or have completed the course).
+ *
+ * This test suite verifies that the ReviewFeedbackService enforces the enrollment requirement
+ * before allowing a user to submit a review for a course.
+ */
+describe('Domain Rule 01 - Enrollment Required For Course Review', () => {
+  beforeAll(async () => {
+    await TestManager.beforeAll();
+  });
+
+  afterAll(async () => {
+    await TestManager.afterAll();
+  });
+
+  beforeEach(async () => {
+    await TestManager.beforeEach();
+  });
+
+  it('01.1 - should prevent creating a review without enrollment', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await expect(
+      reviewFeedbackService.createCourseReview({
+        userId: studentUser.id,
+        courseId: course.id,
+        rating: 5,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_NO_ENROLLMENT));
+  });
+
+  it('01.2 - should allow creating a review with active enrollment', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    const actualResult = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating: 5,
+      reviewText: faker.lorem.paragraph(),
+    });
+
+    expect(actualResult.userId).toBe(studentUser.id);
+    expect(actualResult.courseId).toBe(course.id);
+    expect(actualResult.id).toBeDefined();
+  });
+
+  it('01.3 - should enforce enrollment check for each user-course combination', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course1 = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const course2 = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course1.id,
+    });
+
+    const actualResult = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course1.id,
+      rating: 5,
+    });
+
+    expect(actualResult.id).toBeDefined();
+
+    await expect(
+      reviewFeedbackService.createCourseReview({
+        userId: studentUser.id,
+        courseId: course2.id,
+        rating: 5,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_NO_ENROLLMENT));
+  });
+});
+

--- a/packages/backend-modules/postgres/src/services/review-feedback.test/rules/rule-01-enrollment-required.test.ts
+++ b/packages/backend-modules/postgres/src/services/review-feedback.test/rules/rule-01-enrollment-required.test.ts
@@ -173,4 +173,3 @@ describe('Domain Rule 01 - Enrollment Required For Course Review', () => {
     ).rejects.toThrow(new CustomError(COURSE_REVIEW_NO_ENROLLMENT));
   });
 });
-

--- a/packages/backend-modules/postgres/src/services/review-feedback.test/rules/rule-02-one-review-per-user-course.test.ts
+++ b/packages/backend-modules/postgres/src/services/review-feedback.test/rules/rule-02-one-review-per-user-course.test.ts
@@ -1,0 +1,264 @@
+import {
+  CustomError,
+  COURSE_REVIEW_ALREADY_EXISTS,
+} from '@repo/http-errors';
+import { TestManager } from '../../../test-manager.test';
+import { ReviewFeedbackService } from '../../review-feedback.service';
+import { UserService } from '../../user.service';
+import { CourseManagementService } from '../../course-management.service';
+import { LearningProgressService } from '../../learning-progress.service';
+import { Instructor } from '@repo/postgres/entities/instructor.entity';
+import { faker } from '@faker-js/faker';
+
+/**
+ * DOMAIN RULE 02: Only one review record is permitted per user per course.
+ *
+ * This test suite verifies that the ReviewFeedbackService enforces the constraint
+ * that a user can only submit one review per course.
+ */
+describe('Domain Rule 02 - One Review Per User Per Course', () => {
+  beforeAll(async () => {
+    await TestManager.beforeAll();
+  });
+
+  afterAll(async () => {
+    await TestManager.afterAll();
+  });
+
+  beforeEach(async () => {
+    await TestManager.beforeEach();
+  });
+
+  it('02.1 - should prevent creating a second review for the same course by the same user', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating: 5,
+    });
+
+    await expect(
+      reviewFeedbackService.createCourseReview({
+        userId: studentUser.id,
+        courseId: course.id,
+        rating: 4,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_ALREADY_EXISTS));
+  });
+
+  it('02.2 - should allow different users to review the same course', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser1 = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const studentUser2 = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser1.id,
+      courseId: course.id,
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser2.id,
+      courseId: course.id,
+    });
+
+    const review1 = await reviewFeedbackService.createCourseReview({
+      userId: studentUser1.id,
+      courseId: course.id,
+      rating: 5,
+    });
+
+    const review2 = await reviewFeedbackService.createCourseReview({
+      userId: studentUser2.id,
+      courseId: course.id,
+      rating: 4,
+    });
+
+    expect(review1.id).toBeDefined();
+    expect(review2.id).toBeDefined();
+    expect(review1.id).not.toBe(review2.id);
+  });
+
+  it('02.3 - should allow the same user to review different courses', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course1 = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const course2 = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course1.id,
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course2.id,
+    });
+
+    const review1 = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course1.id,
+      rating: 5,
+    });
+
+    const review2 = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course2.id,
+      rating: 4,
+    });
+
+    expect(review1.id).toBeDefined();
+    expect(review2.id).toBeDefined();
+    expect(review1.id).not.toBe(review2.id);
+  });
+
+  it('02.4 - should allow user to update their existing review instead of creating a new one', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    const review = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating: 3,
+    });
+
+    const updatedReview = await reviewFeedbackService.updateCourseReview({
+      reviewId: review.id,
+      rating: 5,
+    });
+
+    expect(updatedReview.id).toBe(review.id);
+    expect(updatedReview.rating).toBe(5);
+  });
+});
+

--- a/packages/backend-modules/postgres/src/services/review-feedback.test/rules/rule-02-one-review-per-user-course.test.ts
+++ b/packages/backend-modules/postgres/src/services/review-feedback.test/rules/rule-02-one-review-per-user-course.test.ts
@@ -1,7 +1,4 @@
-import {
-  CustomError,
-  COURSE_REVIEW_ALREADY_EXISTS,
-} from '@repo/http-errors';
+import { CustomError, COURSE_REVIEW_ALREADY_EXISTS } from '@repo/http-errors';
 import { TestManager } from '../../../test-manager.test';
 import { ReviewFeedbackService } from '../../review-feedback.service';
 import { UserService } from '../../user.service';
@@ -261,4 +258,3 @@ describe('Domain Rule 02 - One Review Per User Per Course', () => {
     expect(updatedReview.rating).toBe(5);
   });
 });
-

--- a/packages/backend-modules/postgres/src/services/review-feedback.test/rules/rule-03-rating-between-1-and-5.test.ts
+++ b/packages/backend-modules/postgres/src/services/review-feedback.test/rules/rule-03-rating-between-1-and-5.test.ts
@@ -1,0 +1,409 @@
+import {
+  CustomError,
+  COURSE_REVIEW_INVALID_RATING,
+} from '@repo/http-errors';
+import { TestManager } from '../../../test-manager.test';
+import { ReviewFeedbackService } from '../../review-feedback.service';
+import { UserService } from '../../user.service';
+import { CourseManagementService } from '../../course-management.service';
+import { LearningProgressService } from '../../learning-progress.service';
+import { Instructor } from '@repo/postgres/entities/instructor.entity';
+import { faker } from '@faker-js/faker';
+
+/**
+ * DOMAIN RULE 03: The rating field must be an integer between 1 and 5.
+ *
+ * This test suite verifies that the ReviewFeedbackService enforces the constraint
+ * that ratings must be integers in the range of 1 to 5 (inclusive).
+ */
+describe('Domain Rule 03 - Rating Must Be Between 1 And 5', () => {
+  beforeAll(async () => {
+    await TestManager.beforeAll();
+  });
+
+  afterAll(async () => {
+    await TestManager.afterAll();
+  });
+
+  beforeEach(async () => {
+    await TestManager.beforeEach();
+  });
+
+  it('03.1 - should allow creating a review with rating 1', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    const actualResult = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating: 1,
+    });
+
+    expect(actualResult.rating).toBe(1);
+  });
+
+  it('03.2 - should allow creating a review with rating 5', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    const actualResult = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating: 5,
+    });
+
+    expect(actualResult.rating).toBe(5);
+  });
+
+  it('03.3 - should prevent creating a review with rating 0', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    await expect(
+      reviewFeedbackService.createCourseReview({
+        userId: studentUser.id,
+        courseId: course.id,
+        rating: 0,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_INVALID_RATING));
+  });
+
+  it('03.4 - should prevent creating a review with rating 6', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    await expect(
+      reviewFeedbackService.createCourseReview({
+        userId: studentUser.id,
+        courseId: course.id,
+        rating: 6,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_INVALID_RATING));
+  });
+
+  it('03.5 - should prevent creating a review with negative rating', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    await expect(
+      reviewFeedbackService.createCourseReview({
+        userId: studentUser.id,
+        courseId: course.id,
+        rating: -1,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_INVALID_RATING));
+  });
+
+  it('03.6 - should prevent creating a review with decimal rating', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    await expect(
+      reviewFeedbackService.createCourseReview({
+        userId: studentUser.id,
+        courseId: course.id,
+        rating: 3.5,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_INVALID_RATING));
+  });
+
+  it('03.7 - should allow all valid integer ratings (1-5)', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const validRatings = [1, 2, 3, 4, 5];
+
+    for (const rating of validRatings) {
+      const course = await courseManagementService.createCourse({
+        instructorId: instructor.id,
+        title: faker.lorem.sentence(),
+      });
+
+      const studentUser = await userService.createUser({
+        username: faker.internet.username(),
+        password: faker.internet.password(),
+      });
+
+      await learningProgressService.createEnrollment({
+        userId: studentUser.id,
+        courseId: course.id,
+      });
+
+      const actualResult = await reviewFeedbackService.createCourseReview({
+        userId: studentUser.id,
+        courseId: course.id,
+        rating,
+      });
+
+      expect(actualResult.rating).toBe(rating);
+    }
+  });
+
+  it('03.8 - should enforce rating validation on update', async () => {
+    const reviewFeedbackService = TestManager.getHandler(ReviewFeedbackService);
+    const userService = TestManager.getHandler(UserService);
+    const courseManagementService = TestManager.getHandler(
+      CourseManagementService,
+    );
+    const learningProgressService = TestManager.getHandler(
+      LearningProgressService,
+    );
+
+    const user = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    const instructorRepository = TestManager.getRepository(Instructor);
+    const instructor = instructorRepository.create({
+      userId: user.id,
+      bio: faker.lorem.paragraph(),
+    });
+    await instructorRepository.save(instructor);
+
+    const course = await courseManagementService.createCourse({
+      instructorId: instructor.id,
+      title: faker.lorem.sentence(),
+    });
+
+    const studentUser = await userService.createUser({
+      username: faker.internet.username(),
+      password: faker.internet.password(),
+    });
+
+    await learningProgressService.createEnrollment({
+      userId: studentUser.id,
+      courseId: course.id,
+    });
+
+    const review = await reviewFeedbackService.createCourseReview({
+      userId: studentUser.id,
+      courseId: course.id,
+      rating: 3,
+    });
+
+    await expect(
+      reviewFeedbackService.updateCourseReview({
+        reviewId: review.id,
+        rating: 6,
+      }),
+    ).rejects.toThrow(new CustomError(COURSE_REVIEW_INVALID_RATING));
+  });
+});
+

--- a/packages/backend-modules/postgres/src/services/review-feedback.test/rules/rule-03-rating-between-1-and-5.test.ts
+++ b/packages/backend-modules/postgres/src/services/review-feedback.test/rules/rule-03-rating-between-1-and-5.test.ts
@@ -1,7 +1,4 @@
-import {
-  CustomError,
-  COURSE_REVIEW_INVALID_RATING,
-} from '@repo/http-errors';
+import { CustomError, COURSE_REVIEW_INVALID_RATING } from '@repo/http-errors';
 import { TestManager } from '../../../test-manager.test';
 import { ReviewFeedbackService } from '../../review-feedback.service';
 import { UserService } from '../../user.service';
@@ -406,4 +403,3 @@ describe('Domain Rule 03 - Rating Must Be Between 1 And 5', () => {
     ).rejects.toThrow(new CustomError(COURSE_REVIEW_INVALID_RATING));
   });
 });
-

--- a/packages/http-errors/src/index.ts
+++ b/packages/http-errors/src/index.ts
@@ -251,3 +251,52 @@ export const PROGRESS_NO_ACTIVE_ENROLLMENT: ICustomError = {
   status: HttpStatus.FORBIDDEN,
   description: 'No Active Enrollment Found For Progress Update',
 };
+
+// ============================================================================
+// COURSE REVIEW ERRORS
+// ============================================================================
+
+export const COURSE_REVIEW_NOT_FOUND: ICustomError = {
+  status: HttpStatus.NOT_FOUND,
+  description: 'Course Review Not Found',
+};
+
+export const COURSE_REVIEW_USER_ID_REQUIRED: ICustomError = {
+  status: HttpStatus.BAD_REQUEST,
+  description: 'User ID Is Required For Course Review',
+};
+
+export const COURSE_REVIEW_COURSE_ID_REQUIRED: ICustomError = {
+  status: HttpStatus.BAD_REQUEST,
+  description: 'Course ID Is Required For Course Review',
+};
+
+export const COURSE_REVIEW_RATING_REQUIRED: ICustomError = {
+  status: HttpStatus.BAD_REQUEST,
+  description: 'Rating Is Required For Course Review',
+};
+
+export const COURSE_REVIEW_USER_NOT_FOUND: ICustomError = {
+  status: HttpStatus.BAD_REQUEST,
+  description: 'User Not Found For This Course Review',
+};
+
+export const COURSE_REVIEW_COURSE_NOT_FOUND: ICustomError = {
+  status: HttpStatus.BAD_REQUEST,
+  description: 'Course Not Found For This Course Review',
+};
+
+export const COURSE_REVIEW_ALREADY_EXISTS: ICustomError = {
+  status: HttpStatus.CONFLICT,
+  description: 'User Has Already Reviewed This Course',
+};
+
+export const COURSE_REVIEW_INVALID_RATING: ICustomError = {
+  status: HttpStatus.BAD_REQUEST,
+  description: 'Rating Must Be Between 1 And 5',
+};
+
+export const COURSE_REVIEW_NO_ENROLLMENT: ICustomError = {
+  status: HttpStatus.FORBIDDEN,
+  description: 'User Must Be Enrolled In Course To Submit Review',
+};


### PR DESCRIPTION
- Add ReviewFeedbackService with CRUD operations
- Implement createCourseReview, findCourseReviewById, findCourseReviews, updateCourseReview, deleteCourseReview methods
- Add HTTP error codes for ReviewFeedback domain
- Create comprehensive unit tests for all CRUD methods
- Create domain rule tests (enrollment required, one review per user/course, rating 1-5)
- Export ReviewFeedbackService from services index
- All tests passing (47 tests)

Implements domain rules:
- Rule 01: User must be enrolled to submit review
- Rule 02: One review per user per course
- Rule 03: Rating must be integer between 1 and 5

Closes #10